### PR TITLE
Make chasecam toggle client prediction+smoothing automatically

### DIFF
--- a/Elohim.qc
+++ b/Elohim.qc
@@ -410,9 +410,11 @@ void () elohim_set_aliases =
     stuffcmd(self, "alias quaketv impulse 154\n");              // CRMOD - autocam
     stuffcmd(self, "alias autochase impulse 155\n");    // CRMOD - autochase
     stuffcmd(self, "alias help-camera impulse 156\n");  // CRMOD - camera help
-    stuffcmd(self, "alias sm1 \"echo Smoothing ON ; cl_nolerp 1 ; alias smooth sm0\"\n");       // CRMOD - smooth now uses aliases
-	stuffcmd(self, "alias sm0 \"echo Smoothing OFF ; cl_nolerp 0 ; alias smooth sm1\"\n");  // CRMOD
-	stuffcmd(self, "alias smooth sm1\n");                                                                                                   // CRMOD
+  // Disable broken multi-command alias- set cl_nolerp 1 and cl_predict 0 for chase cams (smooth on)
+  //   stuffcmd(self, "alias sm1 \"echo Smoothing ON ; cl_nolerp 1 ; alias smooth sm0\"\n"); // CRMOD - smooth now uses aliases
+  // Disable broken multi-command alias- set cl_nolerp 0 and cl_predict 1 for normal play (smooth off)
+	// stuffcmd(self, "alias sm0 \"echo Smoothing OFF ; cl_nolerp 0 ; alias smooth sm1\"\n");  // CRMOD
+	// stuffcmd(self, "alias smooth sm1\n");                                                   // CRMOD
 	stuffcmd(self, "alias init echo\n");                            // CRMOD - So clients only see 'init' once
 	
 	self.style = self.style | ELOHIM_FOUND_BINDINGS;

--- a/Observer.qc
+++ b/Observer.qc
@@ -169,10 +169,11 @@ void () observer_walk_start =
     self.movetype = MOVETYPE_WALK;
     self.flags = self.flags - self.flags & FL_ONGROUND;
     self.view_ofs = '0 0 22';
-    if (self.style & ELOHIM_FOUND_BINDINGS)  // CRMOD - don't send sm0 if they don't have that alias
-        stuffcmd(self, "sm0\n");		// CRMOD - smoothing off
-    else
-    	stuffcmd(self, "cl_nolerp 0\n");	// CRMOD - send the real thing instead
+
+    sprint(self, "disabling 'smooth' mode\n");
+    stuffcmd(self, "cl_nolerp 0\n");		// CRMOD - interpolation buffering on (back to default)
+    stuffcmd(self, "cl_predict 1\n");		// CRMOD - client prediction on (back to default)
+
     stuffcmd(self, "v_centerspeed 500\n");
     sprint(self, "walk mode - help-walk for help\n");
     if (!(self.style & ELOHIM_HEADS_UP))
@@ -191,7 +192,11 @@ void () observer_fly_start =
     self.view_ofs = '0 0 22';
     self.flags = self.flags | FL_ONGROUND;
 	self.waterlevel = 0;
-    stuffcmd(self, "sm0\n");		// CRMOD - smoothing off
+
+    sprint(self, "disabling 'smooth' mode\n");
+    stuffcmd(self, "cl_nolerp 0\n");		// CRMOD - interpolation buffering on (back to default)
+    stuffcmd(self, "cl_predict 1\n");		// CRMOD - client prediction on (back to default)
+
     stuffcmd(self, "v_centerspeed 500\n");
     sprint(self, "fly mode - help-fly for help\n");
     if (!(self.style & ELOHIM_HEADS_UP))
@@ -314,7 +319,10 @@ void () observer_chase_start =
     
     if (!(self.style & ELOHIM_HEADS_UP))
         sprint(self, "type 'headsup' for fullscreen display\n");
-	sprint(self, "type 'smooth' to eliminate choppines\n");
+
+    sprint(self, "enabling 'smooth' mode to eliminate choppines\n");
+    stuffcmd(self, "cl_nolerp 1\n");		// CRMOD - interpolation buffering off
+    stuffcmd(self, "cl_predict 0\n");		// CRMOD - client prediction off
 };
 
 //
@@ -356,7 +364,10 @@ void () observer_demo_start =
     sprint(self, "eyecam mode - help-chase for help\n");
     if (!(self.style & ELOHIM_HEADS_UP))
         sprint(self, "type 'headsup' for fullscreen display\n");
-	sprint(self, "type 'smooth' to eliminate choppines\n");
+
+    sprint(self, "enabling 'smooth' mode to eliminate choppines\n");
+    stuffcmd(self, "cl_nolerp 1\n");		// CRMOD - interpolation buffering off
+    stuffcmd(self, "cl_predict 0\n");		// CRMOD - client prediction off
 
 	self.nextthink = -1;
     self.think = SUB_Null;
@@ -477,7 +488,11 @@ void () observer_end =
     self.frags = 0;
 
     observer_check_demo_end();
-    stuffcmd(self, "sm0\n");		// CRMOD - smoothing off
+
+    sprint(self, "disabling 'smooth' mode\n");
+    stuffcmd(self, "cl_nolerp 0\n");		// CRMOD - interpolation buffering on (back to default)
+    stuffcmd(self, "cl_predict 1\n");		// CRMOD - client prediction on (back to default)
+
     stuffcmd(self, "v_centerspeed 500\n");
     // BROKEN
     // if (self.style & ELOHIM_HEADS_UP)

--- a/client.qc
+++ b/client.qc
@@ -474,8 +474,12 @@ void() respawn =
 
     if (deathmatch)
 	{
-		// make a copy of the dead body for appearances sake
-		CopyToBodyQue (self);
+		// Don't leave bodies around in match mode
+		if (!(elohim_playmode & ELOHIM_MATCH_MODE))
+		{
+			// make a copy of the dead body for appearances sake
+			CopyToBodyQue (self);
+		}
 
         // ELOHIM_MOD - changed SetNewParms to SetNewParms2
 		// set default spawn parms

--- a/hud.qc
+++ b/hud.qc
@@ -108,7 +108,7 @@ void hud_update() =
         item = find(world, classname, "item_artifact_super_damage");
         while (item && (item_count < item_slots))
         {
-            WriteString(MSG_ONE, "\sqd");
+            WriteString(MSG_ONE, " \sq");
             WriteString(MSG_ONE, "\x10");
             if (item.nextthink == 0)
             {
@@ -144,7 +144,7 @@ void hud_update() =
         item = find(world, classname, "item_artifact_invulnerability");
         while (item && (item_count < item_slots))
         {
-            WriteString(MSG_ONE, "\spe");
+            WriteString(MSG_ONE, " \sp");
             WriteString(MSG_ONE, "\x10");
             if (item.nextthink == 0)
             {
@@ -180,7 +180,7 @@ void hud_update() =
         item = find(world, classname, "item_artifact_invisibility");
         while (item && (item_count < item_slots))
         {
-            WriteString(MSG_ONE, "\sey");
+            WriteString(MSG_ONE, " \se");
             WriteString(MSG_ONE, "\x10");
             if (item.nextthink == 0)
             {


### PR DESCRIPTION
Set both cl_nolerp and cl_predict to "smooth" settings for chase views and back to default for walk, fly, and leaving observer mode so hopefully we stop having invisible players. Also change powerups to single letters in observer HUD.