### PR TITLE
Observer mode "eyecam" enhancements

### DIFF
--- a/Auto.qc
+++ b/Auto.qc
@@ -20,6 +20,7 @@
 // Prototypes:
 void () observer_chase_start;
 void () observer_camera_start;
+void () observer_demo_start;
 void () observer_set_chase_position;
 vector (vector from, vector to) angles_bestaim;
 void (vector v) angles_fixangle;
@@ -225,6 +226,17 @@ void () auto_chase_start =
 	observer_chase_start();
 };
 	
+// CRMOD
+//  A U T O  D E M O  S T A R T
+//    by CK (hacked together from Paul Baker's chase code)
+//
+//  start autochase from anywhere
+void () auto_demo_start =
+{
+	self.oflags = self.oflags | OBSERVER_GO_AUTO;
+	observer_demo_start();
+};
+
 // CRMOD
 // A U T O  C H A S E
 //   by Paul Baker

--- a/Elohim.qc
+++ b/Elohim.qc
@@ -410,6 +410,7 @@ void () elohim_set_aliases =
     stuffcmd(self, "alias quaketv impulse 154\n");              // CRMOD - autocam
     stuffcmd(self, "alias autochase impulse 155\n");    // CRMOD - autochase
     stuffcmd(self, "alias help-camera impulse 156\n");  // CRMOD - camera help
+    stuffcmd(self, "alias autoeye impulse 157\n");      // CRMOD - autochase in eyecam/demo mode
   // Disable broken multi-command alias- set cl_nolerp 1 and cl_predict 0 for chase cams (smooth on)
   //   stuffcmd(self, "alias sm1 \"echo Smoothing ON ; cl_nolerp 1 ; alias smooth sm0\"\n"); // CRMOD - smooth now uses aliases
   // Disable broken multi-command alias- set cl_nolerp 0 and cl_predict 1 for normal play (smooth off)

--- a/Observer.qc
+++ b/Observer.qc
@@ -1542,6 +1542,7 @@ void () observer_update_status_bar =
 		    self.weaponmodel = string_null;
 		if (self.health < 0)
 			self.health = 1000;
+        self.height = player.height; // Team
 		// CRMOD END
     }
 };

--- a/Observer.qc
+++ b/Observer.qc
@@ -363,7 +363,7 @@ void () observer_demo_start =
     stuffcmd(self, "v_centerspeed 0\n");
     sprint(self, "eyecam mode - help-chase for help\n");
 
-    // CRMOD - auto
+    // CRMOD - auto, tourney
     if (self.oflags & OBSERVER_GO_AUTO)
     {
         sprint(self,"Automatic Eyecam Enabled.\n");
@@ -372,6 +372,8 @@ void () observer_demo_start =
     }
     else
         sprint(self,"type 'autoeye' for automatic eyecam switching\n");
+    if (self.oflags & OBSERVER_TOURNEY)
+        sprint(self,"Tournament Mode Enabled.\n");
     // END_CRMOD
 
     if (!(self.style & ELOHIM_HEADS_UP))
@@ -1039,6 +1041,12 @@ void () observer_set_demo_position =
     // Don't move us around if we're attempting to follow world (no player to chase)
     if (self.movetarget == world)
         return;
+
+    // See if we're looking at an enemy
+    if (self.oflags & OBSERVER_TOURNEY)
+    {
+        observer_find_enemy();
+    }
 
     setorigin(self, self.movetarget.origin);
 

--- a/Observer.qc
+++ b/Observer.qc
@@ -362,6 +362,18 @@ void () observer_demo_start =
     observer_set_demo_position();
     stuffcmd(self, "v_centerspeed 0\n");
     sprint(self, "eyecam mode - help-chase for help\n");
+
+    // CRMOD - auto
+    if (self.oflags & OBSERVER_GO_AUTO)
+    {
+        sprint(self,"Automatic Eyecam Enabled.\n");
+        self.oflags = self.oflags - OBSERVER_GO_AUTO;
+        self.oflags = self.oflags | OBSERVER_AUTO;
+    }
+    else
+        sprint(self,"type 'autoeye' for automatic eyecam switching\n");
+    // END_CRMOD
+
     if (!(self.style & ELOHIM_HEADS_UP))
         sprint(self, "type 'headsup' for fullscreen display\n");
 
@@ -451,6 +463,9 @@ void () observer_start =
 	}
     else if (self.oflags & OBSERVER_DEMO)
 	{
+		if (self.oflags & OBSERVER_AUTO)
+			self.oflags = self.oflags | OBSERVER_GO_AUTO;
+
 		// This is necessary to prevent the other player's model from being 
 		// drawn.  Don't fucking as me why!!!
 		self.nextthink = time + 0.1;
@@ -1006,6 +1021,25 @@ void () observer_set_chase_position =
 //
 void () observer_set_demo_position =
 {
+    // If we're in auto mode, see if we should pick a new target
+    if ((self.oflags & OBSERVER_AUTO) && (self.oflags & OBSERVER_DEMO))
+	{
+        local entity oldmovetarget = self.movetarget;
+        auto_chase();
+
+        // See if we need to move our viewport
+        if ((self.movetarget != world) && (self.movetarget != oldmovetarget))
+        {
+            msg_entity = self;
+            WriteByte(MSG_ONE, SVC_SETVIEWPORT);
+            WriteEntity(MSG_ONE, self.movetarget);
+        }
+    }
+
+    // Don't move us around if we're attempting to follow world (no player to chase)
+    if (self.movetarget == world)
+        return;
+
     setorigin(self, self.movetarget.origin);
 
     if (self.button0)
@@ -1245,10 +1279,12 @@ void () observer_impulse =
 			auto_camera_start();
 		else if (self.impulse == 155)
 			auto_chase_start();
+		else if (self.impulse == 157)
+			auto_demo_start();
     }
     else
     {                                                                              // CRMOD more commands to go observer
-        if ((self.impulse >= 140 && self.impulse <= 143) || self.impulse == 149 || (self.impulse >= 153 && self.impulse <= 155))
+        if ((self.impulse >= 140 && self.impulse <= 143) || self.impulse == 149 || (self.impulse >= 153 && self.impulse <= 155 || self.impulse == 157))
         {
 			if (self.impulse != 140)
 			{
@@ -1268,6 +1304,8 @@ void () observer_impulse =
 					self.oflags = self.oflags | OBSERVER_CAMERA;
 				else if (self.impulse == 154)
 					self.oflags = self.oflags | OBSERVER_CAMERA | OBSERVER_GO_AUTO;
+				else if (self.impulse == 157)
+					self.oflags = self.oflags | OBSERVER_DEMO | OBSERVER_GO_AUTO;
 				// CRMOD END
 			}
 			


### PR DESCRIPTION
* "autoeye" mode which uses a points-based algorithm to decide who to follow (like "autochase" but first-person)
* enemy/target name is now printed on screen for eyecam (like chasecam does)
* followed player's team is now printed/set for chasecam and eyecam so that HUD scores work properly