### PR TITLE
Adjust warp aliases to handle QE disallowing wait/multi-command

### DIFF
--- a/src/admin.qc
+++ b/src/admin.qc
@@ -37,12 +37,20 @@ void () admin_send_aliases1 =
 	temp = self;
 	self = self.owner;
 
+	// episode warp aliases since QE won't let us do two impulses at once
+	stuffcmd(self, "alias warp0 impulse 190\n");
+	stuffcmd(self, "alias warp1 impulse 191\n");
+	stuffcmd(self, "alias warp2 impulse 192\n");
+	stuffcmd(self, "alias warp3 impulse 193\n");
+	stuffcmd(self, "alias warp4 impulse 194\n");
+	stuffcmd(self, "alias warp5 impulse 195\n");
+	stuffcmd(self, "alias warp6 impulse 196\n");
+	
 	//
 	// maps
 	//
 	// e.g.:   alias start impulse 150
 	//
-	stuffcmd(self, "alias w5 \"wait;wait;wait;wait;wait\"\n");
 	local float levelnum, episode;
 	local string szTemp;
 	levelnum = 100;
@@ -55,13 +63,10 @@ void () admin_send_aliases1 =
 
 			stuffcmd(self, "alias ");
 			stuffcmd(self, szTemp);
-			stuffcmd(self, " \"impulse ");
-			szTemp = ftos(190 + episode);
-			stuffcmd(self, szTemp);
-			stuffcmd(self, ";w5;");
 			szTemp = ftos(levelnum - 100 - episode * 10);
+			stuffcmd(self, " ");
 			stuffcmd(self, szTemp);
-			stuffcmd(self, "\"\n");
+			stuffcmd(self, "\n");
 		}
 		levelnum = levelnum + 1;
 	}

--- a/src/elohim.qc
+++ b/src/elohim.qc
@@ -684,9 +684,7 @@ void () elohim_help =
 //
 void () elohim_help_change =
 {
-		sprint(self, "\n");
-		sprint(self, "Το γθαξηε μεφεμσ¬ εξτες τθε ξανε οζ\n");
-		sprint(self, "τθε μεφεμ ιξ τθε γοξσομε®\n");
+		sprint(self, "To change levels, enter warpX then map name\n");
 };
 
 //
@@ -799,15 +797,15 @@ void () elohim_levels =
 		local string name;
 
 		elohim_help_change();
-		sprint(self, "\n");
 
 		// standard levels
-		sprint(self, " start, start0, start1, end\n");
-		sprint(self, " e1m1-e1m8 Όεπισοδε ±Ύ\n");
-		sprint(self, " e2m1-e2m7 Όεπισοδε ²Ύ\n");
-		sprint(self, " e3m1-e3m7 Όεπισοδε ³Ύ\n");
-		sprint(self, " e4m1-e4m8 Όεπισοδε ΄Ύ\n");
-		sprint(self, " dm1-dm6   ΌδεατθνατγθΎ\n");
+		sprint(self, "warp0: start, start0, start1, end, death32c, base32b\n");
+		sprint(self, "warp1: e1m1-e1m8\n");
+		sprint(self, "warp2: e2m1-e2m7\n");
+		sprint(self, "warp3: e3m1-e3m7\n");
+		sprint(self, "warp4: e4m1-e4m8\n");
+		sprint(self, "warp5: dm1-dm8\n");
+		sprint(self, "warp6:\n");
 
 		// user defined levels
 		index = 0;

--- a/src/strings.qc
+++ b/src/strings.qc
@@ -659,17 +659,9 @@ string (float mapnum) strings_get_mapname =
 		if (mapnum == 3)
 			return "end";
 		if (mapnum == 4)
-			return "aerowalk";
+			return "death32c";
 		if (mapnum == 5)
-			return "ztndm3";
-		if (mapnum == 6)
-			return "ztndm4";
-	if (mapnum == 7)
-			return "ultrav";
-	if (mapnum == 8)
-			return "q3dm6qw";
-	if (mapnum == 9)
-			return "aggressr";
+			return "base32b";
 		return "";
 	}
 	if (mapnum < 20)
@@ -766,8 +758,6 @@ string (float mapnum) strings_get_mapname =
 			return "dm7";
 		if (mapnum == 58)
 			return "dm8";
-		if (mapnum == 59)
-			return "death32c";
 		return "";
 	}
 	return array_get_user_map(mapnum - 60);

--- a/src/userdefs.qc
+++ b/src/userdefs.qc
@@ -50,16 +50,17 @@ void () userdefs_init_world =
 	QSMACK5 = utils_stof(temp);
 
 	// User defined maps
-	array_set_user_map(0, "                ltag0");
-	array_set_user_map(1, "                ltag1");
-	array_set_user_map(2, "                ltag2");
-	array_set_user_map(3, "                ltag3");
-	array_set_user_map(4, "                ltag4");
-	array_set_user_map(5, "                ltag5");
-	array_set_user_map(6, "                ltag6");
-	array_set_user_map(7, "                ltag7");
-	array_set_user_map(8, "                ltag8");
-	array_set_user_map(9, "                ltag9");
+	// Manually controlled (at compile) as opposed to ltag0-ltag9 (config?)
+	array_set_user_map(0, "      aerowalk");
+	array_set_user_map(1, "      ztndm3");
+	array_set_user_map(2, "      ultrav");
+	array_set_user_map(3, "      aggressr");
+	array_set_user_map(4, "      cmt3");
+	array_set_user_map(5, "      schloss");
+	array_set_user_map(6, "      skull");
+	array_set_user_map(7, "      bravado");
+	array_set_user_map(8, "      ztndm4");
+	array_set_user_map(9, "      cmt4");
 
 	// Intro message
 	temp = "0 ntag";


### PR DESCRIPTION
"warp" or "levels" command now print how to use warp.
Set `scr_maxlines 20` to be able to see the whole command output

Note some map impulse numbers may have changed and a couple maps were removed!
Custom maps also moved to userdefs.qc!